### PR TITLE
sort translation key asc order before import and export

### DIFF
--- a/src/translate.js
+++ b/src/translate.js
@@ -25,7 +25,7 @@ function deserializeTranslations(translations) {
 
 function serializeTranslations(translations) {
   const data = {};
-  const transKeys = Object.keys(translations);
+  const transKeys = Object.keys(translations).sort();
 
   transKeys.forEach((k) => {
     const translation = translations[k];
@@ -77,7 +77,7 @@ function getRemoteTranslations(auth) {
 function uploadRemoteTranslations(auth, languages, translations) {
   const rows = [["Key", ...languages]];
 
-  const keys = Object.keys(translations);
+  const keys = Object.keys(translations).sort();
 
   keys.forEach((k) => {
     const translation = translations[k];


### PR DESCRIPTION
So that each row in translation is consistent on both remote and local

When translation key is not sorted, the order of each row can be random.
It can cause change to a whole sheet or translation file by simply adding a new translation key.

This pr resolve translation key ordering issue by sorting them in ascending order before saving to the translation file or exporting them to google sheet.

https://user-images.githubusercontent.com/6735658/226616019-2adac712-43cf-4b65-af31-38da733592c7.mov


